### PR TITLE
[hydrated_state_notifier] chore: dependency upgrade

### DIFF
--- a/packages/hydrated_state_notifier/CHANGELOG.md
+++ b/packages/hydrated_state_notifier/CHANGELOG.md
@@ -1,3 +1,8 @@
 ## 1.0.0
 
 - Initial version.
+
+## 2.0.0
+
+- [Breaking Change] Dependency Upgrade
+- support Dart 3.0

--- a/packages/hydrated_state_notifier/pubspec.yaml
+++ b/packages/hydrated_state_notifier/pubspec.yaml
@@ -1,24 +1,24 @@
 name: hydrated_state_notifier
 description: An extension to the state_notifier library which automatically persists and restores state_notifier states.
-version: 1.0.0
+version: 2.0.0
 homepage: https://github.com/predatorx7/hydrated_state_notifier/tree/main/packages/hydrated_state_notifier
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   meta: ^1.3.0
-  state_notifier: ^0.7.0
+  state_notifier: ^1.0.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.16.0
   collection: ^1.15.0
   crypto: ^3.0.0
-  freezed_annotation: ^0.15.0
-  freezed: ^0.15.0+1
+  freezed_annotation: ^2.4.1
+  freezed: ^2.4.7
   json_serializable: ^6.0.0
   json_annotation: ^4.3.0
-  mocktail: ^0.3.0
+  mocktail: ^1.0.3
   path: ^1.8.0
-  uuid: ^3.0.0
+  uuid: ^4.3.3

--- a/packages/hydrated_state_notifier_hive/example/CHANGELOG.md
+++ b/packages/hydrated_state_notifier_hive/example/CHANGELOG.md
@@ -1,3 +1,8 @@
 ## 1.0.0
 
 - Initial version.
+
+## 2.0.0
+
+- [Breaking Change] Dependency Upgrade
+- support Dart 3.0

--- a/packages/hydrated_state_notifier_hive/example/pubspec.yaml
+++ b/packages/hydrated_state_notifier_hive/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     git:
       url: git@github.com:amanxnanda/hydrated_state_notifier.git
       ref: chore/dependency-upgrade
+      path: packages/hydrated_state_notifier
   hydrated_state_notifier_hive:
     path: ../
   path: ^1.8.2

--- a/packages/hydrated_state_notifier_hive/example/pubspec.yaml
+++ b/packages/hydrated_state_notifier_hive/example/pubspec.yaml
@@ -1,14 +1,16 @@
 name: example
 description: A sample command-line application.
 version: 1.0.0
-publish_to: 'none'
+publish_to: "none"
 
 environment:
-  sdk: '>=2.18.4 <3.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   hydrated_state_notifier:
-    path: ../../hydrated_state_notifier
+    git:
+      url: git@github.com:amanxnanda/hydrated_state_notifier.git
+      ref: chore/dependency-upgrade
   hydrated_state_notifier_hive:
     path: ../
   path: ^1.8.2

--- a/packages/hydrated_state_notifier_hive/lib/src/hydrated_cipher.dart
+++ b/packages/hydrated_state_notifier_hive/lib/src/hydrated_cipher.dart
@@ -36,5 +36,5 @@ abstract class HydratedCipher implements HiveCipher {
 /// Default encryption algorithm. Uses AES256 CBC with PKCS7 padding.
 class HydratedAesCipher extends HiveAesCipher implements HydratedCipher {
   /// Create a cipher with the given [key].
-  HydratedAesCipher(List<int> key) : super(key);
+  HydratedAesCipher(super.key);
 }

--- a/packages/hydrated_state_notifier_hive/pubspec.yaml
+++ b/packages/hydrated_state_notifier_hive/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hydrated_state_notifier_hive
 description: An implementation of HydratedStorage from hydrated_state_notifier library which automatically persists and restores states built on top of hive.
-version: 1.0.0
+version: 2.0.0
 publish_to: "none"
 homepage: https://github.com/predatorx7/hydrated_state_notifier/tree/main/packages/hydrated_state_notifier_hive
 
@@ -15,6 +15,7 @@ dependencies:
     git:
       url: git@github.com:amanxnanda/hydrated_state_notifier.git
       ref: chore/dependency-upgrade
+      path: packages/hydrated_state_notifier
 
 dev_dependencies:
   lints: ^3.0.0

--- a/packages/hydrated_state_notifier_hive/pubspec.yaml
+++ b/packages/hydrated_state_notifier_hive/pubspec.yaml
@@ -1,26 +1,30 @@
 name: hydrated_state_notifier_hive
 description: An implementation of HydratedStorage from hydrated_state_notifier library which automatically persists and restores states built on top of hive.
 version: 1.0.0
+publish_to: "none"
 homepage: https://github.com/predatorx7/hydrated_state_notifier/tree/main/packages/hydrated_state_notifier_hive
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   hive: ^2.0.0
   synchronized: ^3.0.0
   meta: ^1.3.0
-  hydrated_state_notifier: ^1.0.0
+  hydrated_state_notifier:
+    git:
+      url: git@github.com:amanxnanda/hydrated_state_notifier.git
+      ref: chore/dependency-upgrade
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.16.0
   collection: ^1.15.0
   crypto: ^3.0.0
-  freezed_annotation: ^0.15.0
-  freezed: ^0.15.0+1
+  freezed_annotation: ^2.4.1
+  freezed: ^2.4.7
   json_serializable: ^6.0.0
   json_annotation: ^4.3.0
-  mocktail: ^0.3.0
+  mocktail: ^1.0.3
   path: ^1.8.0
-  uuid: ^3.0.0
+  uuid: ^4.3.3


### PR DESCRIPTION
Reason for this PR: 
- Fixes dependency conflicts for projects using the latest [`state_notifier`](https://pub.dev/packages/state_notifier)
- Upgrades all the dependencies to the latest